### PR TITLE
Drop redundant buffer start address calculation

### DIFF
--- a/src/ssd1327.cpp
+++ b/src/ssd1327.cpp
@@ -896,7 +896,7 @@ uint8_t *s;
     return; // invalid coordinates
   if (pBuffer == NULL)
   {
-    pBuffer = &ucBackbuffer[(y*iPitch)+(x/2)]; // starting point also
+    pBuffer = ucBackbuffer;
     iLocalPitch = iPitch;
   }
   ssd1327SetPosition(x, y, w, h);


### PR DESCRIPTION
This PR removes the backbuffer-specific address calculation logic in `ssd1327ShowBitmap` since it seems to be redundant with the general calculation just after it. Running the calculation twice causes the display to start further into the buffer than intended and to skip areas.